### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist
 .tox
 .coverage*
 htmlcov
+
+.python-version

--- a/jsonfield/tests/jsonfield_test_app/models.py
+++ b/jsonfield/tests/jsonfield_test_app/models.py
@@ -1,5 +1,5 @@
-from django.contrib.postgres.fields import JSONField as PostgresJSONField
 from django.db import models
+from django.db.models import JSONField as DjangoJSONField
 from jsonfield.fields import JSONField
 
 
@@ -34,7 +34,7 @@ class CallableDefaultModel(models.Model):
 
 class PostgresParallelModel(models.Model):
     library_json = JSONField()
-    postgres_json = PostgresJSONField()
+    postgres_json = DjangoJSONField()
 
     class Meta:
         app_label = 'jsonfield'

--- a/jsonfield/tests/test_fields.py
+++ b/jsonfield/tests/test_fields.py
@@ -3,7 +3,7 @@ from unittest import skipUnless
 from django.db import connection
 from django.core import serializers
 from django.test import TestCase as DjangoTestCase
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django import forms
 
 from jsonfield.tests.jsonfield_test_app.models import *  # NOQA
@@ -61,7 +61,7 @@ class JSONFieldTest(DjangoTestCase):
         formfield = field.formfield()
         self.assertRaisesMessage(
             forms.ValidationError,
-            force_text(formfield.error_messages['required']),
+            force_str(formfield.error_messages['required']),
             formfield.clean,
             value='')
 
@@ -70,7 +70,7 @@ class JSONFieldTest(DjangoTestCase):
         formfield = field.formfield()
         self.assertRaisesMessage(
             forms.ValidationError,
-            force_text(formfield.error_messages['required']),
+            force_str(formfield.error_messages['required']),
             formfield.clean,
             value=None)
 

--- a/tests.py
+++ b/tests.py
@@ -36,8 +36,17 @@ def main():
     global_settings.STATIC_URL = "/static/"
     global_settings.MEDIA_ROOT = os.path.join(BASE_PATH, 'static')
     global_settings.STATIC_ROOT = global_settings.MEDIA_ROOT
-
     global_settings.SECRET_KEY = '334ebe58-a77d-4321-9d01-a7d2cb8d3eea'
+    if hasattr(global_settings, 'PASSWORD_RESET_TIMEOUT_DAYS'):
+        delattr(global_settings, 'PASSWORD_RESET_TIMEOUT_DAYS')
+    global_settings.PASSWORD_RESET_TIMEOUT = 259200
+    global_settings.DEFAULT_HASHING_ALGORITHM = 'sha256'
+    if hasattr(global_settings, 'STORAGES'):
+        if hasattr(global_settings, 'DEFAULT_FILE_STORAGE'):
+            delattr(global_settings, 'DEFAULT_FILE_STORAGE')
+        if hasattr(global_settings, 'STATICFILES_STORAGE'):
+            delattr(global_settings, 'STATICFILES_STORAGE')
+
     from django.test.utils import get_runner
     test_runner = get_runner(global_settings)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,16 @@
 [tox]
 skip_missing_interpreters = true
-envlist = py{27,34,35}-django{111}-{postgres,mysql,sqlite}
-          py{35,36,37}-django{20,21,22}-{postgres,mysql,sqlite}
-          py{36,37}-django{30}-{postgres,mysql,sqlite}
+envlist = py{37,38}-django{32}-{sqlite}
+          py{38,39,310}-django{40,41,42}-{sqlite}
 
 [testenv]
 deps=
   coverage
-  django111: Django>=1.11,<2.0
-  django20: Django>=2.0,<2.1
-  django21: Django>=2.1,<2.2
-  django22: Django>=2.2,<2.3
-  django30: Django>=3.0,<3.1
+  django32: Django>=3.2,<3.3
+  django40: Django>=4.0,<4.1
+  django41: Django>=4.1,<4.2
+  django42: Django>=4.2,<4.3
+  django{40,41,42}: backports.zoneinfo>=0.2.1;python_version<"3.9"
   psycopg2-binary  # Always installed for defining PostgresParallelModel
   six
   mysql: mysqlclient
@@ -24,6 +23,7 @@ setenv=
   postgres: DB_ENGINE=postgresql_psycopg2
   sqlite: DB_ENGINE=sqlite3
   mysql: DB_ENGINE=mysql
+  PASSWORD_RESET_TIMEOUT=259200
 commands=
   postgres: createdb jsonfield-{envname}
   mysql: mysqladmin --user={env:MYSQL_USER:root} --password={env:MYSQL_PASSWORD:} create jsonfield-{envname}
@@ -38,6 +38,7 @@ whitelist_externals=
 [testenv:flake8]
 deps=
   flake8
+
 commands=
   flake8 jsonfield
 


### PR DESCRIPTION
# Unit Tests
- [x] Perform fixes

## Django 4.0.10
* [Django 4.0 deprecations](https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0):
* See the [Django 3.0 release notes](https://docs.djangoproject.com/en/5.0/releases/3.0/#deprecated-features-3-0) for more details on these changes.

- [x] **django.utils.encoding.force_text()** and **smart_text()** will be removed.  The aliases are  force_str() and smart_str().
- [x] **django.utils.http.urlquote()**, **urlquote_plus()**, **urlunquote()**, and **urlunquote_plus()** will be removed.
- [x] **django.utils.translation.ugettext()**, **ugettext_lazy()**, **ugettext_noop()**, **ungettext()**, and **ungettext_lazy()** will be removed.
- [x] **django.views.i18n.set_language()** will no longer set the user language in **request.session** (key **django.utils.translation.LANGUAGE_SESSION_KEY**). 
- [x] **alias=None** will be required in the signature of **django.db.models.Expression.get_group_by_cols()** subclasses.
- [x] **django.utils.text.unescape_entities()** will be removed.
- [x] **django.utils.http.is_safe_url()** will be removed.

* See the [Django 3.1 release notes](https://docs.djangoproject.com/en/5.0/releases/3.1/#deprecated-features-3-1) for more details on these changes.
- [x] **The PASSWORD_RESET_TIMEOUT_DAYS** setting will be removed.
- [x] The undocumented usage of the **isnull** lookup with non-boolean values as the right-hand side will no longer be allowed.
- [x] The **django.db.models.query_utils.InvalidQuery** exception class will be removed.
- [x] The **django-admin.py** entry point will be removed.
- [x] Support for the pre-Django 3.1 encoding format of cookies values used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] The **providing_args** argument for **django.dispatch.Signal** will be removed.
- [x] The **length** argument for **django.utils.crypto.get_random_string()** will be required.
- [x] The model **NullBooleanField** will be removed. A stub field will remain for compatibility with historical migrations. 
- [x] The model **django.contrib.postgres.fields.JSONField** will be removed. A stub field will remain for compatibility with historical migrations.
- [x] **django.contrib.postgres.forms.JSONField**, **django.contrib.postgres.fields.jsonb.KeyTransform**, and **django.contrib.postgres.fields.jsonb.KeyTextTransform** will be removed.
- [x] The **DEFAULT_HASHING_ALGORITHM** transitional setting will be removed.
- [x] Support for passing raw column aliases to **QuerySet.order_by()** will be removed.
- [x] **django.conf.urls.url()** will be removed.  It's an alias of **django.urls.re_path()**.
- [x] The **get_response** argument for **django.utils.deprecation.MiddlewareMixin.__init__()** will be required and won’t accept **None**.
- [x] The **list** message for **ModelMultipleChoiceField** will be removed.
- [x] The **HttpRequest.is_ajax()** method will be removed.
- [x] The **{% ifequal %}** and **{% ifnotequal %}** template tags will be removed.

### pre-Django 3.1 SHA-1
- [x] Support for the pre-Django 3.1 password reset tokens in the admin site (that use the SHA-1 hashing algorithm) will be removed.
- [x] Support for the pre-Django 3.1 encoding format of sessions will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.Signer** signatures (encoded with the SHA-1 algorithm) will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.dumps()** signatures (encoded with the SHA-1 algorithm) in **django.core.signing.loads()** will be removed.
- [x] Support for the pre-Django 3.1 user sessions (that use the SHA-1 algorithm) will be removed.

## Django 4.1.13
See the [Django 3.2 release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#deprecated-features-3-2) for more details on these changes.

- [x] Support for assigning objects which don’t support creating deep copies with **copy.deepcopy()** to class attributes in **TestCase.setUpTestData()** will be removed.
- [x] The **whitelist** argument and **domain_whitelist** attribute of **django.core.validators.EmailValidator** will be removed.
- [x] **TransactionTestCase.assertQuerysetEqual()** will no longer automatically call **repr()** on a queryset when compared to string values.
- [x] Support for the pre-Django 3.2 format of messages used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] **BaseCommand.requires_system_checks** won’t support boolean values. Use '__all__' instead of True, and [] (an empty list) instead of False.
- [x] **django.core.cache.backends.memcached.MemcachedCache** will be removed.
- [x] The **default_app_config** module variable will be removed. 
